### PR TITLE
Faster stats generation

### DIFF
--- a/create_song_stats.py
+++ b/create_song_stats.py
@@ -1,57 +1,58 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import time
+from collections import defaultdict
 import util
 
+def build_counts(conn):
+    # counts[song_id][year] = count
+    counts = {}
+    years = conn.execute("SELECT DISTINCT year FROM minutes").fetchall()
+    for (song_id,) in conn.execute("SELECT id FROM songs"):
+        counts[song_id] = {}
+        for year, in years:
+            counts[song_id][year] = 0
+
+    # Get leads by song and year; compute counts
+    cursor = conn.execute("""
+        SELECT song_id, COUNT(*), minutes.Year
+        FROM song_leader_joins
+        JOIN minutes ON song_leader_joins.minutes_id = minutes.id
+        GROUP BY minutes.Year, song_id
+    """)
+    for (song_id, count, year) in cursor:
+        counts[song_id][year] += count
+
+    return counts
+
+def build_ranks(counts):
+    # ranks[year] = sorted [(count, song_id), ...]
+    ranks = defaultdict(list)
+    for song_id, yearcount in counts.iteritems():
+        for year, count in yearcount.iteritems():
+            ranks[year].append((count, song_id))
+    # Sort desc by count then asc by song_id
+    for data in ranks.itervalues():
+        data.sort(key=lambda i: (-i[0], i[1]))
+    return ranks
+
 def create_stats(conn):
-    curs = conn.cursor()
-
-    curs.execute("SELECT DISTINCT year FROM minutes")
-    year_rows = curs.fetchall()
-    num_years = len(year_rows)
-    year_count = 0
-
-    tic = time.time()
-
-    for year_row in year_rows:
-        year = year_row[0]
+    ranks = build_ranks(build_counts(conn))
+    # values = [(song_id, year, lead_count, rank), ...]
+    values = []
+    for year in sorted(ranks.keys()):
         rank = 1
-        curs.execute("SELECT song_id, COUNT(*) FROM song_leader_joins \
-            INNER JOIN minutes ON song_leader_joins.minutes_id = minutes.id \
-            WHERE minutes.year = ? GROUP BY song_id ORDER BY count(*) DESC", \
-            [year])
-        song_rows = curs.fetchall()
-        for song_row in song_rows:
-            song_id = song_row[0]
-            lead_count = song_row[1]
-            curs.execute("INSERT INTO song_stats (year, song_id, lead_count, \
-                rank) VALUES (?,?,?,?)", [year, song_id, lead_count, rank])
-            rank = rank + 1
-        conn.commit()
+        last_count = 0
+        for i, (count, song_id) in enumerate(ranks[year]):
+            if count != last_count:
+                rank = i + 1
+            last_count = count
+            values.append((song_id, year, count, rank))
 
-        # fill in zeros
-        curs.execute("SELECT id FROM songs")
-        song_rows = curs.fetchall()
-        curs.execute("SELECT DISTINCT year FROM song_stats")
-        year_rows = curs.fetchall()
-        for song_row in song_rows:
-            for year_row in year_rows:
-                song_id = song_row[0]
-                year = year_row[0]
-                curs.execute("SELECT * FROM song_stats WHERE song_id = ? AND \
-                    year = ?", [song_id, year])
-                if curs.fetchone() is None:
-                    curs.execute("INSERT INTO song_stats (year, song_id, \
-                        lead_count, rank) VALUES (?,?,0,554)", [year, song_id])
-        conn.commit()
+    conn.executemany("INSERT INTO song_stats (song_id, year, lead_count, rank) VALUES (?, ?, ?, ?)", values)
+    conn.commit()
+    print "created %d song_stats records" % len(values)
 
-        year_count = year_count + 1
-        toc = time.time()
-        est_remaining = float(toc - tic) / year_count * (num_years - year_count)
-        print "est rem: %f" % (est_remaining) # / 60)
-
-    curs.close()
 
 def delete_stats(conn):
     curs = conn.cursor()

--- a/create_song_stats.py
+++ b/create_song_stats.py
@@ -4,40 +4,22 @@
 from collections import defaultdict
 import util
 
-def build_counts(conn):
-    # counts[song_id][year] = count
-    counts = {}
-    years = conn.execute("SELECT DISTINCT year FROM minutes").fetchall()
-    for (song_id,) in conn.execute("SELECT id FROM songs"):
-        counts[song_id] = {}
-        for year, in years:
-            counts[song_id][year] = 0
-
-    # Get leads by song and year; compute counts
+def build_ranks(conn):
+    # ranks[year] = sorted [(count, song_id), ...]
+    ranks = defaultdict(list)
     cursor = conn.execute("""
         SELECT song_id, COUNT(*), minutes.Year
         FROM song_leader_joins
         JOIN minutes ON song_leader_joins.minutes_id = minutes.id
         GROUP BY minutes.Year, song_id
+        ORDER BY minutes.Year ASC, COUNT(*) DESC, song_id ASC
     """)
     for (song_id, count, year) in cursor:
-        counts[song_id][year] += count
-
-    return counts
-
-def build_ranks(counts):
-    # ranks[year] = sorted [(count, song_id), ...]
-    ranks = defaultdict(list)
-    for song_id, yearcount in counts.iteritems():
-        for year, count in yearcount.iteritems():
-            ranks[year].append((count, song_id))
-    # Sort desc by count then asc by song_id
-    for data in ranks.itervalues():
-        data.sort(key=lambda i: (-i[0], i[1]))
+        ranks[year].append((count, song_id))
     return ranks
 
 def create_stats(conn):
-    ranks = build_ranks(build_counts(conn))
+    ranks = build_ranks(conn)
     # values = [(song_id, year, lead_count, rank), ...]
     values = []
     for year in sorted(ranks.keys()):


### PR DESCRIPTION
This branch includes changes to create_leader_stats.py and create_song_stats.py to make them a lot faster.  For the most part it uses techniques similar to #5 (wait to commit until the end).

The output from this (dumped leaders, leaders_song_stats, and song_stats tables) is identical to the previous method with a couple of exceptions:

* What appears to be floating point precision differences in a few leader entropy calculations
* song_stats rank is calculated slightly differently.  In the old version, songs with the same lead_count have a different rank, except songs with 0 leads, which are all set to rank 554.  This version gives songs with the same lead_count the same rank, but still increments the rank counter correctly.  If there's some other code that relies on the previous rank scheme, I can make a couple of changes to keep it exactly the same.

Note that song_stats are actually still incorrect since co-leads of a song are counted once per leader, not once per lead.  That will take a different PR.