### PR TITLE
Add overrides for incorrect IsDenson fields

### DIFF
--- a/denson_override.csv
+++ b/denson_override.csv
@@ -3,3 +3,4 @@
 "Tennessee State Sacred Harp Singing","Saturday, October 17, 2015",1
 "Tennessee State Sacred Harp Singing","Saturday, October 15, 2016",1
 "Tennessee State Sacred Harp Singing","Saturday, October 14, 2017",1
+"Tennessee State Sacred Harp Singing","Saturday, October 20, 2018",1

--- a/denson_override.csv
+++ b/denson_override.csv
@@ -1,0 +1,5 @@
+"Name","Date","IsDenson"
+"Tennessee State Sacred Harp Singing","Saturday, October 11, 2014",1
+"Tennessee State Sacred Harp Singing","Saturday, October 17, 2015",1
+"Tennessee State Sacred Harp Singing","Saturday, October 15, 2016",1
+"Tennessee State Sacred Harp Singing","Saturday, October 14, 2017",1

--- a/insert_minutes.py
+++ b/insert_minutes.py
@@ -23,8 +23,21 @@ def insert_minutes(conn):
     conn.commit()
     curs.close()
 
+def fix_denson(conn):
+    curs = conn.cursor()
+
+    reader = csv.reader(open("denson_override.csv", 'rb'))
+    reader.next() # skip headers
+    for row in reader:
+        curs.execute("UPDATE minutes SET IsDenson=? WHERE Name LIKE ? AND \
+            Date LIKE ?", (row[2], row[0], row[1]))
+
+    conn.commit()
+    curs.close()
+
 if __name__ == '__main__':
     db = util.open_db()
     delete_minutes(db)
     insert_minutes(db)
+    fix_denson(db)
     db.close()


### PR DESCRIPTION
There are some singings that are incorrectly identified as *not* denson. This sticks an override in a csv file for now.  A solution to #4 might include arbitrary data fixes (not just leader lists), in which case that new system should be used instead of this PR.