### PR TITLE
Lowercase recording song numbers

### DIFF
--- a/spider_base.py
+++ b/spider_base.py
@@ -75,6 +75,7 @@ class SpiderBase(scrapy.Spider):
         pages = []
         urls = []
         for pagenum, url in song_data:
+            pagenum = pagenum.lower()
             altpage = ''
             if pagenum[-1:] in ('t', 'b'):
                 altpage = pagenum[:-1]


### PR DESCRIPTION
A handful of shapenotecds tracks use uppercase `T` or `B`, and the scraper chokes on these b/c the song numbers are lowercase in the db.